### PR TITLE
Set black rank when user clicks 'It's me' for black.

### DIFF
--- a/android/src/main/java/org/ligi/gobandroid_hd/ui/alerts/GameInfoDialog.java
+++ b/android/src/main/java/org/ligi/gobandroid_hd/ui/alerts/GameInfoDialog.java
@@ -82,7 +82,7 @@ public class GameInfoDialog extends GobandroidDialog {
     void onBlack() {
         if (checkUserNamePresent()) {
             blackNameEdit.setText(App.getGobandroidSettings().getUsername());
-            white_rank_et.setText(App.getGobandroidSettings().getRank());
+            black_rank_et.setText(App.getGobandroidSettings().getRank());
         }
         EditText et;
     }


### PR DESCRIPTION
 Previously this would set black name and white rank.

Fixes issue 136.