### PR TITLE
Fix to capture stones in SGF review

### DIFF
--- a/android/src/main/java/org/ligi/gobandroid_hd/logic/GoGame.kt
+++ b/android/src/main/java/org/ligi/gobandroid_hd/logic/GoGame.kt
@@ -175,7 +175,6 @@ class GoGame @JvmOverloads constructor(size: Int, handicap: Int = 0) {
         val matching_move = actMove.getNextMoveOnCell(cell)
         if (matching_move != null) {
             redo(matching_move)
-            actMove.redo(calcBoard, matching_move)
             return MoveStatus.VALID
         }
 

--- a/android/src/main/java/org/ligi/gobandroid_hd/logic/GoMove.java
+++ b/android/src/main/java/org/ligi/gobandroid_hd/logic/GoMove.java
@@ -94,6 +94,7 @@ public class GoMove {
             return this;
         }
 
+        next.buildCaptures(board);
         next.apply(board);
         return next;
     }
@@ -160,6 +161,9 @@ public class GoMove {
 
     private void buildCaptures(StatefulGoBoard board) {
         captures.clear();
+        if(cell == null) {
+            return;
+        }
 
         //temporarily apply the move in order to calculate captures
         byte previousStatus = board.getCellKind(cell);

--- a/android/src/main/java/org/ligi/gobandroid_hd/logic/sgf/SGFReader.java
+++ b/android/src/main/java/org/ligi/gobandroid_hd/logic/sgf/SGFReader.java
@@ -255,6 +255,12 @@ public class SGFReader {
                     variationList.add(game.getActMove());
                 }
 
+                if(game.actMove.isFirstMove()) {
+                    byte lastPlayer = marker == Marker.WHITE_MOVE
+                        ? GoDefinitions.PLAYER_BLACK : GoDefinitions.PLAYER_WHITE;
+                    game.actMove.setPlayer(lastPlayer);
+                }
+
                 if ((breakon & BREAKON_FIRSTMOVE) > 0) {
                     break_pulled = true;
                 }

--- a/android/src/test/java/org/ligi/gobandroid_hd/TheSGFReader.kt
+++ b/android/src/test/java/org/ligi/gobandroid_hd/TheSGFReader.kt
@@ -2,6 +2,7 @@ package org.ligi.gobandroid_hd
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.ligi.gobandroid_hd.logic.CellImpl
 import org.ligi.gobandroid_hd.logic.GoDefinitions
 import org.ligi.gobandroid_hd.logic.markers.TextMarker
 import org.ligi.gobandroid_hd.logic.sgf.SGFReader
@@ -57,9 +58,19 @@ class TheSGFReader {
             // https://github.com/ligi/gobandroid/issues/106
     fun testReadSGFWithFirstMoveWhiteAndCapture() {
         val game = SGFReader.sgf2game(readAsset("test_sgfs/first_move_capture_and_white.sgf"), null)
-
         assertThat(game.findLastMove().movePos).isEqualTo(2)
         assertThat(game.findLastMove().player).isEqualTo(GoDefinitions.PLAYER_BLACK)
+
+        val moveZero = game.actMove
+        assertThat(moveZero.hasNextMove()).isTrue()
+        val nextMoveCell = moveZero.getnextMove(0).cell
+        assertThat(nextMoveCell).isNotNull()
+        val cellToCapture = CellImpl(nextMoveCell.x -1, nextMoveCell.y)
+        assertThat(game.calcBoard.getCellKind(cellToCapture)).isEqualTo(GoDefinitions.STONE_BLACK)
+        game.redo(0)
+        assertThat(game.calcBoard.getCellKind(cellToCapture)).isEqualTo(GoDefinitions.STONE_NONE)
+        val redoMove = game.actMove
+        assertThat(redoMove.captures.size).isEqualTo(1)
     }
 
     @Test

--- a/android/src/test/java/org/ligi/gobandroid_hd/TheSGFReader.kt
+++ b/android/src/test/java/org/ligi/gobandroid_hd/TheSGFReader.kt
@@ -2,6 +2,7 @@ package org.ligi.gobandroid_hd
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.ligi.gobandroid_hd.logic.GoDefinitions
 import org.ligi.gobandroid_hd.logic.markers.TextMarker
 import org.ligi.gobandroid_hd.logic.sgf.SGFReader
 
@@ -58,6 +59,7 @@ class TheSGFReader {
         val game = SGFReader.sgf2game(readAsset("test_sgfs/first_move_capture_and_white.sgf"), null)
 
         assertThat(game.findLastMove().movePos).isEqualTo(2)
+        assertThat(game.findLastMove().player).isEqualTo(GoDefinitions.PLAYER_BLACK)
     }
 
     @Test


### PR DESCRIPTION
This fixes the issue mentioned in PR #199. It also makes white the first player when reviewing an SGF if the first move played is white.